### PR TITLE
Libfcrepo 390

### DIFF
--- a/classes/pcdm.py
+++ b/classes/pcdm.py
@@ -10,6 +10,7 @@ from rdflib import Namespace
 import sys
 import logging
 from uuid import uuid4
+import threading
 
 #============================================================================
 # NAMESPACE BINDINGS
@@ -203,6 +204,29 @@ class Repository():
             self.logger.error("Failed to create transaction")
             raise RESTAPIException(response)
 
+    def maintain_transaction(self, **kwargs):
+        if self.transaction is not None:
+            url = os.path.join(self.transaction, 'fcr:tx')
+            self.logger.info(
+                "Maintaining transaction {0}".format(self.transaction)
+                )
+            self.logger.debug("POST {0}".format(url))
+            response = requests.post(url, cert=self.client_cert, auth=self.auth,
+                        verify=self.server_cert, **kwargs)
+            self.logger.debug("%s %s", response.status_code, response.reason)
+            if response.status_code == 204:
+                self.logger.info(
+                    "Transaction {0} is active until {1}".format(
+                        self.transaction, response.headers['Expires']
+                        )
+                    )
+                return True
+            else:
+                self.logger.error(
+                    "Failed to maintain transaction {0}".format(self.transaction)
+                    )
+                raise RESTAPIException(response)
+
     def commit_transaction(self, **kwargs):
         if self.transaction is not None:
             url = os.path.join(self.transaction, 'fcr:tx/fcr:commit')
@@ -251,6 +275,21 @@ class Repository():
             return '/'.join([p.strip('/') for p in (self.endpoint, relpath)])
         else:
             return uri
+
+# based on https://stackoverflow.com/a/12435256/5124907
+class TransactionKeepAlive(threading.Thread):
+    def __init__(self, repository, interval):
+        super(TransactionKeepAlive, self).__init__(name='TransactionKeepAlive')
+        self.repository = repository
+        self.interval = interval
+        self.stopped = threading.Event()
+
+    def run(self):
+        while not self.stopped.wait(self.interval):
+            self.repository.maintain_transaction()
+
+    def stop(self):
+        self.stopped.set()
 
 #============================================================================
 # PCDM RESOURCE (COMMON METHODS FOR ALL OBJECTS)

--- a/config/logging.yml
+++ b/config/logging.yml
@@ -1,7 +1,7 @@
 version: 1
 formatters:
   full:
-    format: '%(levelname)s|%(asctime)s|%(name)s|%(message)s'
+    format: '%(levelname)s|%(asctime)s|%(threadName)s|%(name)s|%(message)s'
   messageonly:
     format: '%(message)s'
 handlers:

--- a/load.py
+++ b/load.py
@@ -165,6 +165,11 @@ def main():
                         action='store_true'
                         )
 
+    parser.add_argument('--ignore', '-i',
+                        help='file listing items to ignore',
+                        action='store'
+                        )
+
     args = parser.parse_args()
 
     if not args.quiet:
@@ -241,6 +246,15 @@ def main():
 
         logger.info('Found {0} completed items'.format(len(completed)))
 
+        if args.ignore is not None:
+            try:
+                ignored = util.ItemLog(args.ignore, fieldnames, 'path')
+            except Exception as e:
+                logger.error('Non-standard ignore file specified: {0}'.format(e))
+                sys.exit(1)
+        else:
+            ignored = []
+
         skipfile = os.path.join(log_location, 'skipped.load.{0}.csv'.format(now))
         skipped = util.ItemLog(skipfile, fieldnames, 'path')
 
@@ -251,6 +265,9 @@ def main():
                 logger.info("Stopping after {0} item(s)".format(args.limit))
                 break
             elif item.path in completed:
+                continue
+            elif item.path in ignored:
+                logger.debug('Ignoring {0}'.format(item.path))
                 continue
 
             logger.info(

--- a/load.py
+++ b/load.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import argparse
 import csv
+from fractions import gcd
 import logging
 from importlib import import_module
 import os.path
@@ -108,6 +109,14 @@ def load_item(fcrepo, item, args, extra=None):
         logger.error("Load interrupted")
         sys.exit(2)
 
+# custom argument type for percentage loads
+def percentage(n):
+    p = int(n)
+    if not p > 0 and p < 100:
+        raise argparse.ArgumentTypeError("Percent param must be 1-99")
+    return p
+
+
 #============================================================================
 # MAIN LOOP
 #============================================================================
@@ -152,6 +161,14 @@ def main():
                                 top-level objects''',
                         action='store',
                         type=int,
+                        default=None
+                        )
+
+    # Load an evenly-spaced percentage of the total batch
+    parser.add_argument('-%', '--percent',
+                        help='load specified percentage of total items',
+                        action='store',
+                        type=percentage,
                         default=None
                         )
 
@@ -269,9 +286,35 @@ def main():
         skipfile = os.path.join(log_location, 'skipped.load.{0}.csv'.format(now))
         skipped = util.ItemLog(skipfile, fieldnames, 'path')
 
+        # set up interval from percent parameter and store set of items to load
+        if args.percent is not None:
+            gr_common_div = gcd(100, args.percent)
+            denom = int(100 / gr_common_div)
+            numer = int(args.percent / gr_common_div)
+            logger.info('Loading {0} of every {1} items (= {2}%)'.format(
+                            numer, denom, args.percent
+                            ))
+            load_set = set()
+            for i in range(int(batch.length / denom)):
+                load_set.update(
+                    [i * denom + j for j in range(denom) if j < numer]
+                    )
+            logger.info(
+                'Items to load: {0}'.format(
+                    ', '.join([str(s) for s in sorted(load_set)])
+                    ))
+
         # create all batch objects in repository
         for n, item in enumerate(batch):
             is_loaded = False
+
+            if args.percent is not None and n not in load_set:
+                logger.info(
+                    'Loading {0} percent, skipping {1}'.format(args.percent, n)
+                    )
+                continue
+
+            # handle load limit parameter
             if args.limit is not None and n >= args.limit:
                 logger.info("Stopping after {0} item(s)".format(args.limit))
                 break


### PR DESCRIPTION
Adds "-%". "--percent" parameter that allows loading a specified percentage of the batch spread evenly across the whole. This option will provide a more representative test load on dev/stage prior to loading on production.

Supports any percentage from 1-99 by converting the percentage to a ratio of "x out of every y" items. For example, 10% would load 1 of every 10 items, while 75% would load 3 out of every 4. NOTE: Within each subset of items, the items loaded are not necessarily evenly distributed, e.g. loading 60% results in the first three of every 5 items being loaded (= 1, 2, 3, ..., 6, 7, 8, ...etc.), but this distribution should be sufficient for the intended purpose.